### PR TITLE
Allow clients to pass down custom http.request options

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -11,12 +11,11 @@
  * @contributor Jason O. Jensen <jason@paperpile.com>
  * @license MIT
  */
-
 var Url = require("url");
 var spawn = require("child_process").spawn;
 var fs = require("fs");
 
-exports.XMLHttpRequest = function() {
+exports.XMLHttpRequest = function(args) {
   "use strict";
 
   /**
@@ -395,6 +394,10 @@ exports.XMLHttpRequest = function() {
       withCredentials: self.withCredentials
     };
 
+    if (args && args.request) {
+      Object.assign(options, args.request)
+    }
+
     // Reset error flag
     errorFlag = false;
 
@@ -469,6 +472,10 @@ exports.XMLHttpRequest = function() {
             headers: headers,
             withCredentials: self.withCredentials
           };
+
+          if (args && args.request) {
+            Object.assign(newOptions, args.request)
+          }
           
           // Make sure we are using the right protocol
           var secure = (settings.url.indexOf('https') === 0);


### PR DESCRIPTION
We are going to enable passing down options to http[s].request function via constructor arguments